### PR TITLE
separate the two lists in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repo contains Rack middleware that can be used to help integrate Nexmo in t
 * Verify [Nexmo signatures](https://developer.nexmo.com/concepts/guides/signing-messages).
 * Plus more to be added
 
+<!-- -->
+
 * [Installation and Usage](#installation-and-usage)
     * [As a standalone application](#as-a-standalone-application)
     * [Mounted into a Rails application](#mounted-into-a-rails-application)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo contains Rack middleware that can be used to help integrate Nexmo in t
 * Verify [Nexmo signatures](https://developer.nexmo.com/concepts/guides/signing-messages).
 * Plus more to be added
 
-<!-- -->
+## Table of contents
 
 * [Installation and Usage](#installation-and-usage)
     * [As a standalone application](#as-a-standalone-application)


### PR DESCRIPTION
The description and the contents listings were merged into one list, this separates them as they are intended.