### PR TITLE
GET/POST support and force signature verification option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ This repo contains Rack middleware that can be used to help integrate Nexmo in t
 
 The verify signature middleware can be used standalone or integrated into a Ruby application. The middleware will return a `403` HTTP status code if the signature is not valid, and will continue the application if it is valid.
 
+### Configuration
+
+You'll need to provide a Nexmo signature secret and signature method using either `ENV` variables or the Rails credentials system.
+
+`.env` example:
+
+```
+NEXMO_SIGNATURE_SECRET = 'your_secret_key'
+NEXMO_SIGNATURE_METHOD = 'md5hash'
+```
+
+Alternatively, you can specify them in the Rails credentials system
+
+```
+EDITOR="code --wait" rails credentials:edit
+```
+
+You can replace the EDITOR variable with your preferred editor. Once the credentials file is open, you are able to add the Nexmo credentials with the following namespacing:
+
+```yaml
+nexmo:
+    signature_secret: your_secret_key
+    signature_method: md5hash
+```
+
+Finally, this middleware will ignore any requests that do not contain a `sig` key. To enforce all requests to be validated, set `NEXMO_SIGNATURE_REQUIRED` to `true` in the environment.
+
 ### As a standalone application
 
 Install the gem on your system:

--- a/lib/nexmo_rack/verify_signature.rb
+++ b/lib/nexmo_rack/verify_signature.rb
@@ -4,6 +4,10 @@ module Nexmo
     class VerifySignature
       def initialize(app)
         @app = app
+        @nexmo = Nexmo::Client.new(
+          signature_secret: signature_secret,
+          signature_method: signature_method
+        )
       end
 
       def call(env)
@@ -19,7 +23,7 @@ module Nexmo
         end
 
         # Otherwise calculate the signature and check that it matches
-        if req.params['sig'] && nexmo_client.check(params)
+        if req.params['sig'] && @nexmo.signature.check(params)
           @app.call(env)
         else
           [403, {}, ['']]
@@ -27,12 +31,6 @@ module Nexmo
       end
 
       private
-
-      def nexmo_client
-        Nexmo::Signature.new(signature_secret)
-        # To be uncommented with the next release of the nexmo-ruby gem
-        # Nexmo::Signature.new(signature_secret, signature_method)
-      end
 
       def signature_secret
         if ENV['NEXMO_SIGNATURE_SECRET']

--- a/lib/nexmo_rack/verify_signature.rb
+++ b/lib/nexmo_rack/verify_signature.rb
@@ -29,18 +29,31 @@ module Nexmo
       private
 
       def nexmo_client
+        Nexmo::Signature.new(signature_secret)
+        # To be uncommented with the next release of the nexmo-ruby gem
+        # Nexmo::Signature.new(signature_secret, signature_method)
+      end
+
+      def signature_secret
         if ENV['NEXMO_SIGNATURE_SECRET']
-          Nexmo::Signature.new(
-            ENV['NEXMO_SIGNATURE_SECRET']
-          )
+          ENV['NEXMO_SIGNATURE_SECRET']
         elsif defined?(Rails) && Rails.application.credentials.nexmo
-          Nexmo::Signature.new(
-            Rails.application.credentials.nexmo[:api_signature_secret]
-          )
+          Rails.application.credentials.nexmo[:signature_secret]
         else
-          raise "No credentials found for Nexmo::Rack::VerifySignature"
+          raise "No signature credentials found for Nexmo::Rack::VerifySignature"
         end
       end
+
+      def signature_method
+        if ENV['NEXMO_SIGNATURE_METHOD']
+          ENV['NEXMO_SIGNATURE_METHOD']
+        elsif defined?(Rails) && Rails.application.credentials.nexmo
+          Rails.application.credentials.nexmo[:signature_method]
+        else
+          raise "No signature method found for Nexmo::Rack::VerifySignature"
+        end
+      end
+
     end
   end
 end

--- a/lib/nexmo_rack/verify_signature.rb
+++ b/lib/nexmo_rack/verify_signature.rb
@@ -12,11 +12,14 @@ module Nexmo
         # Duplicate the request params in case nexmo_client.check() modifies them
         params = req.params.dup
 
-        # If there is no `sig` field, ignore this middleware
-        return @app.call(env) unless req.params['sig']
+        # If there is no `sig` field, ignore this middleware unless we explicitly
+        # require it to be present
+        unless ENV['NEXMO_SIGNATURE_REQUIRED']
+          return @app.call(env) unless req.params['sig']
+        end
 
         # Otherwise calculate the signature and check that it matches
-        if nexmo_client.check(params)
+        if req.params['sig'] && nexmo_client.check(params)
           @app.call(env)
         else
           [403, {}, ['']]
@@ -26,13 +29,13 @@ module Nexmo
       private
 
       def nexmo_client
-        if ENV['NEXMO_API_SIGNATURE']
+        if ENV['NEXMO_SIGNATURE_SECRET']
           Nexmo::Signature.new(
-            ENV['NEXMO_API_SIGNATURE']
+            ENV['NEXMO_SIGNATURE_SECRET']
           )
         elsif defined?(Rails) && Rails.application.credentials.nexmo
           Nexmo::Signature.new(
-            Rails.application.credentials.nexmo[:api_signature]
+            Rails.application.credentials.nexmo[:api_signature_secret]
           )
         else
           raise "No credentials found for Nexmo::Rack::VerifySignature"

--- a/nexmo_rack.gemspec
+++ b/nexmo_rack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{lib}/**/*", "LICENSE.txt", "README.md"]
 
-  spec.add_runtime_dependency('nexmo', '~> 6.0.1')
+  spec.add_runtime_dependency('nexmo', '~> 6.1')
   spec.add_runtime_dependency('rack', '~> 2.0', '>= 2.0.7')
   spec.add_development_dependency('simplecov', '~> 0.16')
   spec.add_development_dependency('coveralls', '~> 0.8.15')

--- a/spec/nexmo_rack/verify_signature_spec.rb
+++ b/spec/nexmo_rack/verify_signature_spec.rb
@@ -5,6 +5,7 @@ require_relative '../../lib/nexmo_rack'
 describe Nexmo::Rack::VerifySignature do
   before do
     ENV['NEXMO_SIGNATURE_SECRET'] = 'secret'
+    ENV['NEXMO_SIGNATURE_METHOD'] = 'md5hash'
     ENV.delete('NEXMO_SIGNATURE_REQUIRED')
   end
 
@@ -52,7 +53,14 @@ describe Nexmo::Rack::VerifySignature do
       ENV.delete('NEXMO_SIGNATURE_SECRET')
       expect {
         Rack::MockRequest.new(app).post('/', params: {'sig' => 'some_value'}) 
-      }.to raise_error "No credentials found for Nexmo::Rack::VerifySignature"
+      }.to raise_error "No signature credentials found for Nexmo::Rack::VerifySignature"
+    end
+
+    xit 'raises if no signature method are found' do
+      ENV.delete('NEXMO_SIGNATURE_METHOD')
+      expect {
+        Rack::MockRequest.new(app).post('/', params: {'sig' => 'some_value'}) 
+      }.to raise_error "No signature method found for Nexmo::Rack::VerifySignature"
     end
   end
 

--- a/spec/nexmo_rack/verify_signature_spec.rb
+++ b/spec/nexmo_rack/verify_signature_spec.rb
@@ -56,7 +56,7 @@ describe Nexmo::Rack::VerifySignature do
       }.to raise_error "No signature credentials found for Nexmo::Rack::VerifySignature"
     end
 
-    xit 'raises if no signature method are found' do
+    it 'raises if no signature method are found' do
       ENV.delete('NEXMO_SIGNATURE_METHOD')
       expect {
         Rack::MockRequest.new(app).post('/', params: {'sig' => 'some_value'}) 
@@ -88,7 +88,7 @@ describe Nexmo::Rack::VerifySignature do
     end
   end
 
-  context 'GET requests' do
+  context 'enforced signature verification' do
     it 'ignores any requests that do not contain a sig field by default' do
       response = Rack::MockRequest.new(app).post('/', params: {'example' => 'here'})
       expect(response.status).to eq(200)

--- a/spec/nexmo_rack/verify_signature_spec.rb
+++ b/spec/nexmo_rack/verify_signature_spec.rb
@@ -32,20 +32,55 @@ describe Nexmo::Rack::VerifySignature do
     })
   end
 
+  # Spaces are URL Encoded in GET requests, which provide a different signature
+  let(:app_valid_get_params) do
+    base_params.merge({
+      'message-timestamp' => '2013-11-21+17:31:42',
+      'sig' => '21dc632821a11e6951a08ceaff871022'
+    })
+  end
+
   let(:app_invalid_params) do
     base_params.merge({
       'sig' => 'xxxx'
     })
   end
 
-  it 'returns a 200 HTTP response for a POST request with a valid verification' do
-    response = Rack::MockRequest.new(app).post('/', params: app_valid_params)
-
-    expect(response.status).to eq(200)
+  context 'credential checks' do
+    it 'raises if no credentials are found' do
+      ENV.delete('NEXMO_API_SIGNATURE')
+      expect {
+        Rack::MockRequest.new(app).post('/', params: {'sig' => 'some_value'}) 
+      }.to raise_error "No credentials found for Nexmo::Rack::VerifySignature"
+    end
   end
 
-  it 'returns a 403 HTTP response for a POST request with an invalid verification' do
-    response = Rack::MockRequest.new(app).post('/', params: app_invalid_params)
-    expect(response.status).to eq(403)
+  context 'POST requests' do
+    it 'passes requests through to the controller for valid signatures' do
+      response = Rack::MockRequest.new(app).post('/', params: app_valid_params)
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns a 403 HTTP response for invalid signatures' do
+      response = Rack::MockRequest.new(app).post('/', params: app_invalid_params)
+      expect(response.status).to eq(403)
+    end
+  end
+
+  context 'GET requests' do
+    it 'passes requests through to the controller for valid signatures' do
+      response = Rack::MockRequest.new(app).get('/', params: app_valid_get_params)
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns a 403 HTTP response for invalid signatures' do
+      response = Rack::MockRequest.new(app).get('/', params: app_invalid_params)
+      expect(response.status).to eq(403)
+    end
+  end
+
+  it 'ignores any requests that do not contain a sig field' do
+    response = Rack::MockRequest.new(app).post('/', params: {'example' => 'here'})
+    expect(response.status).to eq(200)
   end
 end


### PR DESCRIPTION
This PR refactors the logic to:

* Handle both GET and POST requests
* Raise an error when required configuration is missing
* Document how to set the required credentials
* Support changing the signature hashing algorithm used (pending nexmo-ruby release)