### PR TITLE
typo in gemspec homepage url

### DIFF
--- a/nexmo_rack.gemspec
+++ b/nexmo_rack.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.version     = Nexmo::Rack::VERSION
   spec.authors     = ["Nexmo"]
   spec.email       = ["devrel@nexmo.com"]
-  spec.homepage    = "https://github.com/Nexmo/nexmo_rack"
+  spec.homepage    = "https://github.com/Nexmo/nexmo-rack"
   spec.summary     = "Nexmo related middleware to make it easier to work with Nexmo's webhooks. To use it you'll need a Nexmo account. Sign up for free at https://www.nexmo.com"
   spec.description = "Nexmo related middleware to make it easier to work with Nexmo's webhooks"
   spec.license     = "MIT"


### PR DESCRIPTION
The gemspec is pointing to the wrong homepage url