### PR TITLE
Remove dup call

### DIFF
--- a/lib/nexmo_rack/verify_signature.rb
+++ b/lib/nexmo_rack/verify_signature.rb
@@ -13,9 +13,6 @@ module Nexmo
       def call(env)
         req = ::Rack::Request.new(env)
 
-        # Duplicate the request params in case nexmo_client.check() modifies them
-        params = req.params.dup
-
         # If there is no `sig` field, ignore this middleware unless we explicitly
         # require it to be present
         unless ENV['NEXMO_SIGNATURE_REQUIRED']
@@ -23,7 +20,7 @@ module Nexmo
         end
 
         # Otherwise calculate the signature and check that it matches
-        if req.params['sig'] && @nexmo.signature.check(params)
+        if req.params['sig'] && @nexmo.signature.check(req.params)
           @app.call(env)
         else
           [403, {}, ['']]


### PR DESCRIPTION
Removes the unnecessary `req.params.dup` call.

There's a dup call in the Ruby SDK to prevent any modifications to the params, which has existed since the signature checking logic was first introduced: https://github.com/Nexmo/nexmo-ruby/commit/cbcf51faeca84c560d34ab1d19f5c68b55c67913